### PR TITLE
Allow time for app to come up for testing

### DIFF
--- a/.github/workflows/jsv-hawkscan.yml
+++ b/.github/workflows/jsv-hawkscan.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Test with HawkScan
         uses: stackhawk/hawkscan-action@v2.1.2
+        env:
+          NO_PROGRESS: true
         continue-on-error: true
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}

--- a/stackhawk.yml
+++ b/stackhawk.yml
@@ -4,7 +4,7 @@ app:
   env: ${APP_ENV:Development}
   waitForAppTarget:
     path: /login
-    waitTimeoutMillis: 500
+    waitTimeoutMillis: 120000
     pollDelay: 3000
   excludePaths:
     - "/logout"

--- a/stackhawk.yml
+++ b/stackhawk.yml
@@ -1,5 +1,5 @@
 app:
-  applicationId: ${APP_ID:f3f2667a-4001-4dae-8e87-3d89043a6f87}
+  applicationId: ${APP_ID:674ef253-ae44-49cb-ac57-3cc00ecb8dbe}
   host: ${APP_HOST:https://localhost:9000}
   env: ${APP_ENV:Development}
   waitForAppTarget:

--- a/stackhawk.yml
+++ b/stackhawk.yml
@@ -4,7 +4,7 @@ app:
   env: ${APP_ENV:Development}
   waitForAppTarget:
     path: /login
-    waitTimeoutMillis: 120000
+    waitTimeoutMillis: 180000
     pollDelay: 3000
   excludePaths:
     - "/logout"


### PR DESCRIPTION
This PR increases the amount of time StackHawk will wait for JavaSpringVulny to come up before scanning. It also includes a change to reduce clutter in the StackHawk console logs.